### PR TITLE
Convert includes from camel to snake case

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -4,6 +4,7 @@ Renderers
 import copy
 from collections import OrderedDict
 
+import inflection
 from django.utils import six, encoding
 from rest_framework import relations
 from rest_framework import renderers
@@ -237,6 +238,7 @@ class JSONRenderer(renderers.JSONRenderer):
         context = current_serializer.context
         included_serializers = utils.get_included_serializers(current_serializer)
         included_resources = copy.copy(included_resources)
+        included_resources = [inflection.underscore(value) for value in included_resources]
 
         for field_name, field in six.iteritems(fields):
             # Skip URL field

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -1,3 +1,4 @@
+import inflection
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.exceptions import ParseError
 from rest_framework.serializers import *
@@ -75,7 +76,7 @@ class IncludedResourcesValidationMixin(object):
             serializers = get_included_serializers(serializer_class)
             if serializers is None:
                 raise ParseError('This endpoint does not support the include parameter')
-            this_field_name = field_path[0]
+            this_field_name = inflection.underscore(field_path[0])
             this_included_serializer = serializers.get(this_field_name)
             if this_included_serializer is None:
                 raise ParseError(


### PR DESCRIPTION
Ideally, we wouldn't underscore, we'd use the same mechanism that the serializers use for converting incoming keys to the appropriate format for matching.

However, this is actually [how the rest of the package does things](https://github.com/django-json-api/django-rest-framework-json-api/blob/develop/rest_framework_json_api/parsers.py#L32), so there's a greater problem.
